### PR TITLE
feat: implement bulk card import modal

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -18,7 +18,6 @@ type ConfirmModalProps = {
   successDescription?: string;
   errorMessage?: string;
   children: React.ReactNode;
-  onClose: () => void | Promise<void>;
 };
 
 export default function ConfirmModal({
@@ -37,12 +36,12 @@ export default function ConfirmModal({
   const handleConfirm = async () => {
     setLoading(true);
     try {
-      await Promise.resolve(action());
+      await action();
       setConfirmOpen(false);
       setSuccessOpen(true);
     } catch (err) {
-      alert(errorMessage);
       console.error(err);
+      alert(errorMessage);
     } finally {
       setLoading(false);
     }

--- a/src/components/common/ImportModal.tsx
+++ b/src/components/common/ImportModal.tsx
@@ -1,162 +1,137 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useMemo } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { useMemo, useState } from "react";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/Button";
 import { Textarea } from "@/components/ui/textarea";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
+import { importBulkCards } from "@/utils/importBulkCards";
+import type { ImportCard } from "@/utils/importBulkCards";
 
 interface ImportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onImport: (cards: any[]) => void;
+  onImport: (cards: ImportCard[]) => void;
 }
 
-export const ImportModal = ({
+export default function ImportModal({
   isOpen,
   onClose,
   onImport,
-}: ImportModalProps) => {
+}: ImportModalProps) {
   const [text, setText] = useState("");
-  const [termDelimiter, setTermDelimiter] = useState("\\t");
-  const [cardDelimiter, setCardDelimiter] = useState("\\n");
+  const [termDelimiter, setTermDelimiter] = useState<"tab" | "comma">("tab");
+  const [cardDelimiter, setCardDelimiter] = useState<"newline" | "semicolon">(
+    "newline"
+  );
 
   const parsedCards = useMemo(() => {
-    if (!text.trim()) return [];
+    return importBulkCards(text, cardDelimiter, termDelimiter).map((c) => ({
+      term: c.term,
+      definition: c.definition,
+      example: c.example ?? "",
+      image_url: "",
+    }));
+  }, [text, cardDelimiter, termDelimiter]);
 
-    const actualCardDelim = cardDelimiter === "\\n" ? "\n" : cardDelimiter;
-    const actualTermDelim = termDelimiter === "\\t" ? "\t" : termDelimiter;
-
-    return text
-      .split(actualCardDelim)
-      .map((line) => {
-        const parts = line.split(actualTermDelim);
-        if (parts.length >= 2) {
-          return {
-            term: parts[0].trim(),
-            definition: parts[1].trim(),
-            example: "",
-            image_url: "",
-          };
-        }
-        return null;
-      })
-      .filter((card) => card !== null);
-  }, [text, termDelimiter, cardDelimiter]);
-
-  const handleSubmit = () => {
+  const handleImport = () => {
+    if (parsedCards.length === 0) return;
     onImport(parsedCards);
     setText("");
     onClose();
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl p-0 overflow-hidden border-none shadow-2xl">
-        <DialogHeader className="p-6 pb-0">
-          <DialogTitle className="text-2xl font-bold text-slate-400">
-            Import
-          </DialogTitle>
-        </DialogHeader>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="max-w-3xl">
+        <div className="space-y-2">
+          <p>
+            <span className="font-bold">Enter data:</span> Copy and paste data
+            here (from Word, Excel, Google Docs, etc.)
+          </p>
+          <Textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder={`From 1\tDefinition 1\tExample 1
+From 2\tDefinition 2\tExample 2
+From 3\tDefinition 3\tExample 3`}
+            className="min-h-[200px]"
+          />
+        </div>
 
-        <div className="p-6 space-y-6">
-          <div className="space-y-2">
-            <Label className="font-bold text-slate-700">
-              Enter data:{" "}
-              <span className="font-normal text-slate-500">
-                Copy and paste data here (from Word, Excel, Google Docs, etc.)
-              </span>
-            </Label>
-            <Textarea
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder="Word 1    Definition 1&#10;Word 2    Definition 2"
-              className="min-h-[220px] bg-white border-2 border-slate-200 focus:border-primary rounded-xl transition-all"
-            />
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <DelimiterGroup
-              label="Between terminology and definitions"
-              value={termDelimiter}
-              onChange={setTermDelimiter}
-              options={[
-                { label: "Tab", value: "\\t" },
-                { label: "Comma", value: "," },
-              ]}
-            />
-            <DelimiterGroup
-              label="Between the cards"
-              value={cardDelimiter}
-              onChange={setCardDelimiter}
-              options={[
-                { label: "New line", value: "\\n" },
-                { label: "Semicolon", value: ";" },
-              ]}
-            />
-          </div>
-
-          <div className="py-2">
-            <p className="text-sm font-bold text-slate-800">
-              Preview <span className="text-primary">{parsedCards.length}</span>{" "}
-              cards
+        <div className="grid grid-cols-2 gap-6">
+          <div>
+            <p className="font-semibold text-sm mb-2">
+              Between terminology & definition
             </p>
-            {parsedCards.length === 0 && text.trim() && (
-              <p className="text-xs text-red-500 mt-1 italic">
-                No content available for preview. Check your delimiters.
-              </p>
-            )}
+            <RadioGroup
+              value={termDelimiter}
+              onValueChange={(v) => setTermDelimiter(v as any)}
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="tab" id="tab" />
+                <Label htmlFor="tab">Tab</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="comma" id="comma" />
+                <Label htmlFor="comma">Comma</Label>
+              </div>
+            </RadioGroup>
           </div>
 
-          <div className="flex justify-end gap-3 pt-4 border-t border-slate-100">
-            <Button
-              variant="ghost"
-              onClick={onClose}
-              className="rounded-full px-8 bg-slate-50 hover:bg-slate-100 text-slate-600 font-bold"
+          <div>
+            <p className="font-semibold text-sm mb-2">Between the cards</p>
+            <RadioGroup
+              value={cardDelimiter}
+              onValueChange={(v) => setCardDelimiter(v as any)}
             >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSubmit}
-              disabled={parsedCards.length === 0}
-              className="rounded-full px-12 bg-[#8B5CF6] hover:bg-[#7C3AED] text-white font-bold shadow-lg disabled:opacity-50"
-            >
-              Import
-            </Button>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="newline" id="newline" />
+                <Label htmlFor="newline">New line</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="semicolon" id="semicolon" />
+                <Label htmlFor="semicolon">Semicolon</Label>
+              </div>
+            </RadioGroup>
           </div>
+        </div>
+
+        <div>
+          <p className="text-sm font-semibold">
+            Preview: <span className="text-primary">{parsedCards.length}</span>{" "}
+            cards
+          </p>
+
+          {parsedCards.length === 0 && text.trim() && (
+            <p className="text-xs text-red-500 italic">
+              No content available for preview.
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-3 pt-4">
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            className="rounded-full"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleImport}
+            disabled={parsedCards.length === 0}
+            className="rounded-full"
+          >
+            Import
+          </Button>
         </div>
       </DialogContent>
     </Dialog>
   );
-};
-
-const DelimiterGroup = ({ label, value, onChange, options }: any) => (
-  <div className="space-y-3">
-    <p className="font-bold text-[13px] text-slate-800">{label}</p>
-    <RadioGroup value={value} onValueChange={onChange} className="space-y-2">
-      {options.map((opt: any) => (
-        <div
-          key={opt.value}
-          className="flex items-center space-x-2 cursor-pointer group"
-        >
-          <RadioGroupItem
-            value={opt.value}
-            id={opt.value}
-            className="border-slate-300 text-primary"
-          />
-          <Label
-            htmlFor={opt.value}
-            className="text-sm font-medium text-slate-600 group-hover:text-primary cursor-pointer"
-          >
-            {opt.label}
-          </Label>
-        </div>
-      ))}
-    </RadioGroup>
-  </div>
-);
+}

--- a/src/components/common/UserDropdown.tsx
+++ b/src/components/common/UserDropdown.tsx
@@ -62,7 +62,6 @@ export default function UserDropdown() {
               title="Confirm logout this source?"
               description="Are you sure you want to logout? This action cannot be undone."
               action={logout}
-              onClose={() => {}}
             >
               <div className="flex items-center w-full px-2 py-2 text-sm text-red-600 cursor-pointer">
                 <LogOutIcon className="mr-2 h-4 w-4" />

--- a/src/components/set/LibraryItem.tsx
+++ b/src/components/set/LibraryItem.tsx
@@ -88,7 +88,6 @@ const LibraryItem: React.FC<LibraryItemProps> = ({ item, onDeleteSuccess }) => {
                     title="Confirm delete set?"
                     description="Are you sure you want to delete this set? This action cannot be undone."
                     action={handleConfirmDelete}
-                    onClose={() => {}}
                   >
                     <div className="flex items-center w-full px-2 py-2 text-sm text-red-600 cursor-pointer">
                       <Trash2 className="mr-2 h-4 w-4" />

--- a/src/components/set/ModalPublicSet.tsx
+++ b/src/components/set/ModalPublicSet.tsx
@@ -45,11 +45,13 @@ export function ModalPublicSet({ open, onClose, defaultRole, onSave }: Props) {
         </DialogHeader>
 
         <div className="flex items-center gap-2">
-          <Input type="email"
+          <Input
+            type="email"
             placeholder="Enter email address"
             value={inviteEmail}
             onChange={(e) => setInviteEmail(e.target.value)}
-          className="border bg-white rounded-md px-3 py-2 text-sm w-full"/>
+            className="border bg-white rounded-md px-3 py-2 text-sm w-full"
+          />
 
           <Select
             value={inviteRole}

--- a/src/components/set/SetForm.tsx
+++ b/src/components/set/SetForm.tsx
@@ -85,7 +85,6 @@ export function SetForm({ index, disabled = false, onRemove }: Props) {
                 action={onRemove}
                 successTitle="Deleted"
                 successDescription="Card removed."
-                onClose={() => {}}
               >
                 <ActionTooltip label="Delete card" side="bottom">
                   <Trash2 className="cursor-pointer text-muted-foreground hover:text-destructive" />

--- a/src/components/set/SetFormContainer.tsx
+++ b/src/components/set/SetFormContainer.tsx
@@ -9,7 +9,7 @@ import { SetForm } from "./SetForm";
 import { SetFormHeader } from "./SetFormHeader";
 import { SetFormControls } from "./SetFormControls";
 import { SetFormFooter } from "./SetFormFooter";
-import { ModalPublicSet } from "./ModalPuclicSet";
+import { ModalPublicSet } from "./ModalPublicSet";
 import { InputSet } from "../common/InputSet";
 import { Textarea } from "../ui/textarea";
 
@@ -40,7 +40,6 @@ export function SetFormContainer({
   const navigate = useNavigate();
   const isViewMode = mode === "view";
   const isCreateMode = mode === "create";
-  // const isEditMode = mode === "edit";
 
   const [submitAction, setSubmitAction] = useState<SubmitAction>(
     isCreateMode ? "create" : "update"
@@ -52,11 +51,7 @@ export function SetFormContainer({
     mode: "onTouched",
     defaultValues,
   });
-  const { reset } = methods;
 
-  useEffect(() => {
-    reset(defaultValues);
-  }, [defaultValues, reset]);
   const {
     register,
     control,
@@ -65,7 +60,7 @@ export function SetFormContainer({
     formState: { isSubmitting, errors },
   } = methods;
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, replace } = useFieldArray({
     control,
     name: "cards",
   });
@@ -76,19 +71,24 @@ export function SetFormContainer({
     if (!draftKey) return;
 
     const subscription = methods.watch((value) => {
-      const draftData = {
-        ...value,
-        cards: value.cards?.map((card: any) => ({
-          ...card,
-          image_url: typeof card?.image_url === "string" ? card.image_url : "",
-        })),
-      };
-      localStorage.setItem(draftKey, JSON.stringify(draftData));
+      localStorage.setItem(
+        draftKey,
+        JSON.stringify({
+          ...value,
+          cards: value.cards?.map((card: any) => ({
+            ...card,
+            image_url: typeof card?.image_url === "string" ? card.image_url : "",
+          })),
+        })
+      );
     });
 
     return () => subscription.unsubscribe();
   }, [methods, draftKey]);
 
+  const handleImportCards = (cards: SetFormValues["cards"]) => {
+    replace(cards);
+  };
   const handleFormSubmit = async (data: SetFormValues) => {
     if (isViewMode) return;
     await onSubmit(data, submitAction);
@@ -172,8 +172,8 @@ export function SetFormContainer({
         {!isViewMode && (
           <SetFormControls
             control={control}
+            onImportCards={handleImportCards}
             onDeleteAllCards={async () => {
-              if (fields.length === 0) return;
               for (let i = fields.length - 1; i >= 0; i--) remove(i);
             }}
           />

--- a/src/components/set/SetFormControls.tsx
+++ b/src/components/set/SetFormControls.tsx
@@ -1,87 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState } from "react";
-import { Button } from "@/components/ui/Button";
-import ConfirmModal from "../common/ConfirmModal";
 import { useFieldArray, type Control } from "react-hook-form";
+import { Trash2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import ConfirmModal from "@/components/common/ConfirmModal";
+import ImportModal from "@/components/common/ImportModal";
+import type { ImportCard } from "@/utils/importBulkCards";
 import type { SetFormValues } from "@/schema/flashCard.schema";
-import { Trash2 } from "lucide-react";
-import { ActionTooltip } from "../common/ActionTooltip";
-import { ImportModal } from "@/components/common/ImportModal";
 
 type Props = {
   control: Control<SetFormValues>;
-  onDeleteAllCards?: () => void;
+  onImportCards: (cards: SetFormValues["cards"]) => void;
+  onDeleteAllCards: () => void | Promise<void>;
 };
 
-export function SetFormControls({ control, onDeleteAllCards }: Props) {
-  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
+export function SetFormControls({
+  control,
+  onImportCards,
+  onDeleteAllCards,
+}: Props) {
+  const [openImportModal, setOpenImportModal] = useState(false);
 
-  const { fields, remove, append } = useFieldArray({
+  const { fields } = useFieldArray({
     control,
     name: "cards",
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleBulkImport = (newCards: any[]) => {
-    newCards.forEach((card) => {
-      append({
-        term: card.term,
-        definition: card.definition,
-        example: card.example || "",
-        image_url: card.image_url || "",
-      });
-    });
-  };
+  const handleImport = (parsed: ImportCard[]) => {
+    const cards: SetFormValues["cards"] = parsed.map((card) => ({
+      term: card.term,
+      definition: card.definition,
+      example: card.example || "",
+      image_url: "",
+    }));
 
-  const handleDeleteAll = async () => {
-    if (fields.length === 0) return;
-
-    if (onDeleteAllCards) {
-      await onDeleteAllCards();
-    } else {
-      for (let i = fields.length - 1; i >= 0; i--) {
-        remove(i);
-      }
-    }
+    onImportCards(cards);
+    setOpenImportModal(false);
   };
 
   return (
     <div className="flex justify-between items-center py-2">
-      <div className="flex items-center gap-2">
-        <ActionTooltip
-          label="Import from Copy paste or Word, Excel"
-          side="bottom"
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setOpenImportModal(true)}
+          className="rounded-full"
         >
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setIsImportModalOpen(true)}
-            className="rounded-full border-slate-200 text-slate-500 text-xs h-8 hover:bg-slate-50"
-          >
-            + Import
-          </Button>
-        </ActionTooltip>
+          <Plus />
+          Import
+        </Button>
 
         <ImportModal
-          isOpen={isImportModalOpen}
-          onClose={() => setIsImportModalOpen(false)}
-          onImport={handleBulkImport}
+          isOpen={openImportModal}
+          onClose={() => setOpenImportModal(false)}
+          onImport={handleImport}
         />
       </div>
 
       {fields.length > 0 && (
         <ConfirmModal
-          title="Confirm Delete all Cards"
-          description="This action cannot be undone. All current cards in this set will be removed."
-          action={handleDeleteAll}
-          successTitle="Success!"
-          successDescription="All cards have been deleted."
-          onClose={() => {}}
+          title="Delete all cards?"
+          description="This action cannot be undone."
+          action={onDeleteAllCards}
+          successTitle="Deleted"
+          successDescription="All cards have been removed."
         >
-          <div className="p-1.5 hover:bg-red-50 rounded-full transition-colors cursor-pointer group">
-            <ActionTooltip label="Delete all cards" side="bottom">
-              <Trash2 className="h-5 w-5 text-muted-foreground group-hover:text-destructive" />
-            </ActionTooltip>
-          </div>
+          <Trash2 className="w-5 h-5 text-red-500 cursor-pointer" />
         </ConfirmModal>
       )}
     </div>

--- a/src/components/set/SetFormHeader.tsx
+++ b/src/components/set/SetFormHeader.tsx
@@ -56,7 +56,7 @@ export function SetFormHeader({
               action={onDelete}
               successTitle="Deleted"
               successDescription="Set has been deleted."
-              onClose={() => {}}
+              // onClose={() => {}}
             >
               <Button
                 type="button"

--- a/src/pages/CreateSetPage.tsx
+++ b/src/pages/CreateSetPage.tsx
@@ -29,42 +29,41 @@ export default function CreateSetPage() {
 
   const handleCreate = async (data: SetFormValues, action: SubmitAction) => {
     try {
-      const validInitialCards = data.cards.filter(
+      const validCards = data.cards.filter(
         (c) => c.term?.trim() || c.definition?.trim()
       );
 
-      if (validInitialCards.length === 0) {
+      if (validCards.length === 0) {
         toast.error("At least one card is required.");
         return;
       }
 
       const processedCards = [];
-      for (const card of validInitialCards) {
-        let finalUrl = "";
+
+      for (const card of validCards) {
+        let imageUrl = "";
         const val = card.image_url as any;
 
-        if (typeof val === "string") {
-          finalUrl = val;
-        } else if (val instanceof File || val instanceof Blob) {
-          finalUrl = await UploadService.uploadImage(val);
+        if (typeof val === "string") imageUrl = val;
+        else if (val instanceof File || val instanceof Blob) {
+          imageUrl = await UploadService.uploadImage(val);
         }
 
         processedCards.push({
           term: card.term?.trim() || "",
           definition: card.definition?.trim() || "",
           example: card.example?.trim() || "",
-          image_url: finalUrl,
+          image_url: imageUrl,
         });
       }
 
-      const createdSetResponse = await SetService.createSet({
+      const res = await SetService.createSet({
         title: data.title,
         description: data.description,
         isPublic: data.isPublic,
       });
 
-      const setId =
-        createdSetResponse.data?.id || (createdSetResponse as any).id;
+      const setId = res.data?.id || (res as any).id;
 
       await SetService.bulkAddCards(setId, processedCards);
 
@@ -76,7 +75,7 @@ export default function CreateSetPage() {
       });
 
       localStorage.removeItem(CREATE_DRAFT_KEY);
-      toast.success("Create Set sucessfully!");
+      toast.success("Create Set successfully!");
 
       navigate(
         action === "create_and_study"

--- a/src/utils/importBulkCards.ts
+++ b/src/utils/importBulkCards.ts
@@ -1,0 +1,40 @@
+export type ImportCard = {
+  term: string;
+  definition: string;
+  example?: string;
+};
+
+export function importBulkCards(
+  text: string,
+  cardDelimiter: "newline" | "semicolon",
+  termDelimiter: "tab" | "comma"
+): ImportCard[] {
+  if (!text.trim()) return [];
+
+  const cardSplit =
+    cardDelimiter === "newline" ? /\r?\n/ : ";";
+
+  const termSplit =
+    termDelimiter === "tab" ? "\t" : ",";
+
+  return text
+    .split(cardSplit)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split(termSplit).map((p) => p.trim());
+
+      const term = parts[0];
+      const definition = parts[1];
+      const example = parts[2];
+
+      if (!term || !definition) return null;
+
+      return {
+        term,
+        definition,
+        example,
+      };
+    })
+    .filter(Boolean) as ImportCard[];
+}


### PR DESCRIPTION
Import nhiều card chỉ với một lần dán dữ liệu
Tab / Dấu phẩy (,) giữa term – definition – example
Xuống dòng / Dấu chấm phẩy (;) để phân tách các card
Có preview số lượng card trước khi import
Card được render ngay bằng useFieldArray.replace
Thêm component ImportModal
Tạo util importBulkCards để xử lý và parse dữ liệu

Cách kiểm tra
Vào trang Create Set
Nhấn Import
<img width="1890" height="933" alt="image" src="https://github.com/user-attachments/assets/c90b3ab1-7b81-48d3-98a6-9656dba5c758" />
Dán dữ liệu vào ô textarea
<img width="1880" height="906" alt="image" src="https://github.com/user-attachments/assets/eefb0ac0-4823-499d-a789-33896ad747f1" />
Chọn đúng ký tự phân cách
<img width="1866" height="878" alt="image" src="https://github.com/user-attachments/assets/ab364894-c824-4bd8-b68e-ff6b50634d2f" />
<img width="1865" height="879" alt="image" src="https://github.com/user-attachments/assets/4a1767d5-4238-4e3b-aef8-c13489c1a156" />
Nhấn Import
Kiểm tra card hiển thị ngay trong form
<img width="1876" height="930" alt="image" src="https://github.com/user-attachments/assets/2e617062-0927-498b-92e3-196b2cb84e1c" />
