### PR TITLE
feat/access management

### DIFF
--- a/src/components/learn/Toggle.tsx
+++ b/src/components/learn/Toggle.tsx
@@ -1,46 +1,76 @@
 import { Bookmark, Users, Share, Ellipsis } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Button } from "@/components/ui/Button";
+import { ModalPublicSet } from "@/components/set/ModalPublicSet";
+import { useState } from "react";
 
-export function ToggleGroupSpacing() {
+type Props = {
+  isSaved?: boolean;
+  onToggleSave?: () => void;
+  onOpenGroup?: () => void;
+  onOpenMore?: () => void;
+  setId: string;
+};
+
+export function ToggleGroupSpacing({
+  isSaved = false,
+  onToggleSave,
+  onOpenGroup,
+  onOpenMore,
+  setId,
+}: Props) {
+  const [openShareModal, setOpenShareModal] = useState(false);
+
   return (
-    <div className="flex items-center gap-2">
-      <ToggleGroup
-        type="multiple"
-        variant="outline"
-        className="flex gap-2"
-      >
-        <ToggleGroupItem
-          value="saved"
-          aria-label="Toggle saved"
-          className=" bg-white
-            gap-1 px-3
-            data-[state=on]:bg-transparent
-            data-[state=on]:[&>svg]:fill-blue-500
-            data-[state=on]:[&>svg]:stroke-blue-500
-          "
-        >
-          <Bookmark className="h-4 w-4" />
-          Save
-        </ToggleGroupItem>
+    <>
+      <div className="flex items-center gap-2">
+        <ToggleGroup type="single" value={isSaved ? "saved" : ""}>
+          <ToggleGroupItem
+            value="saved"
+            aria-label="Save"
+            onClick={onToggleSave}
+            variant="outline"
+            className="bg-white gap-1 px-3 data-[state=on]:text-blue-600"
+          >
+            <Bookmark className="h-4 w-4" />
+            Save
+          </ToggleGroupItem>
+        </ToggleGroup>
 
-        <ToggleGroupItem
-          value="group"
-          aria-label="Toggle group"
-          className="gap-1 px-3 bg-white"
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onOpenGroup}
+          className="gap-1 px-3"
         >
           <Users className="h-4 w-4" />
           Group
-        </ToggleGroupItem>
-      </ToggleGroup>
+        </Button>
 
-      <Button size="icon" variant="outline" aria-label="Share">
-        <Share className="h-4 w-4" />
-      </Button>
+        <Button
+          size="icon"
+          variant="outline"
+          aria-label="Share"
+          onClick={() => setOpenShareModal(true)}
+        >
+          <Share className="h-4 w-4" />
+        </Button>
 
-      <Button size="icon" variant="outline" aria-label="More">
-        <Ellipsis className="h-4 w-4" />
-      </Button>
-    </div>
+        <Button
+          size="icon"
+          variant="outline"
+          aria-label="More"
+          onClick={onOpenMore}
+        >
+          <Ellipsis className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <ModalPublicSet
+        open={openShareModal}
+        onClose={setOpenShareModal}
+        setId={setId}
+      />
+    </>
   );
 }

--- a/src/components/set/AccessList.tsx
+++ b/src/components/set/AccessList.tsx
@@ -1,0 +1,57 @@
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import UserInfo from "../user/UserInfo";
+import type { AccessUser } from "@/services/access.service";
+
+type Props = {
+  accessList?: AccessUser[];
+  onRemove: (id: string) => void;
+};
+
+export default function AccessList({ accessList = [], onRemove }: Props) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium text-muted-foreground">
+        People with access
+      </p>
+      <div className="flex items-center justify-between py-2">
+        <UserInfo />
+        <span className="text-sm text-muted-foreground">Owner</span>
+      </div>
+      {accessList.map((item) => {
+        const initial = item.user?.username
+          ? item.user.username.charAt(0).toUpperCase()
+          : "U";
+        return (
+          <div key={item.id} className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
+                {initial}
+              </div>
+              <div>
+                <p className="text-sm font-medium">
+                  {item.user?.username ?? "Unknown user"}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {item.user?.email ?? ""}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                {item.permission === "EDIT" ? "Editor" : "Viewer"}
+              </span>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => onRemove(item.id)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/set/InviteInput.tsx
+++ b/src/components/set/InviteInput.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/Button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type Role = "viewer" | "editor";
+
+type Props = {
+  loading: boolean;
+  error: string | null;
+  onInvite: (email: string, role: Role, reset: () => void) => void;
+};
+
+const isValidEmail = (email: string) =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+export default function InviteInput({ loading, error, onInvite }: Props) {
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Role>("viewer");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const submit = () => {
+    const value = email.trim().toLowerCase();
+    if (!value) {
+      setLocalError("Please enter an email");
+      return;
+    }
+    if (!isValidEmail(value)) {
+      setLocalError("Invalid email format");
+      return;
+    }
+    onInvite(value, role, () => {
+      setEmail("");
+      setRole("viewer");
+    });
+  };
+  return (
+    <>
+      <div className="flex gap-2">
+        <Input
+          type="email"
+          placeholder="Add people"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            setLocalError(null);
+          }}
+        />
+        <Select value={role} onValueChange={(v) => setRole(v as Role)}>
+          <SelectTrigger className="w-28">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="viewer">Viewer</SelectItem>
+            <SelectItem value="editor">Editor</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button onClick={submit} disabled={loading}>
+          Send
+        </Button>
+      </div>
+      {(localError || error) && (
+        <span className="text-xs text-destructive">{localError || error}</span>
+      )}
+    </>
+  );
+}

--- a/src/components/set/ModalPublicSet.tsx
+++ b/src/components/set/ModalPublicSet.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -14,45 +16,86 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
-import { Globe } from "lucide-react";
-import { useState } from "react";
+import { X, Link2 } from "lucide-react";
+import UserInfo from "../user/UserInfo";
+import { useSetAccess } from "@/hooks/useSetAccess";
+import type { AccessUser } from "@/services/access.service";
+import PublicAccessSelect from "./PublicAccessSelect";
+import { toast } from "sonner";
 
 type Role = "viewer" | "editor";
-
 type Props = {
   open: boolean;
-  onClose: () => void;
-  defaultRole: Role;
-  onSave: (role: Role) => void;
+  onClose: (open: boolean) => void;
+  setId?: string;
+  defaultRole?: Role;
 };
-
-export function ModalPublicSet({ open, onClose, defaultRole, onSave }: Props) {
-  const [publicRole, setPublicRole] = useState<Role>(defaultRole);
+const isValidEmail = (email: string) =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+export function ModalPublicSet({
+  open,
+  onClose,
+  setId,
+  defaultRole = "viewer",
+}: Props) {
+  const { accessList, invite, remove, loading } = useSetAccess(setId);
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState<Role>("viewer");
-
-  const handleSave = () => {
-    onSave(publicRole);
+  const [error, setError] = useState<string | null>(null);
+  const handleInvite = async () => {
+    if (!setId || loading) return;
+    const email = inviteEmail.trim().toLowerCase();
+    if (!email) {
+      setError("Please enter an email");
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setError("Invalid email format");
+      return;
+    }
+    setError(null);
+    try {
+      await invite(email, inviteRole === "editor" ? "EDIT" : "VIEW");
+      setInviteEmail("");
+      setInviteRole("viewer");
+    } catch (err: any) {
+      setError(
+        err?.response?.data?.message ??
+          "Email does not exist or cannot be invited"
+      );
+    }
+  };
+  const handleCopyLink = async () => {
+    if (!setId) return;
+    await navigator.clipboard.writeText(
+      `${window.location.origin}/sets/${setId}/study`
+    );
+    toast.success("Link copied to clipboard");
+  };
+  const handleClose = () => {
+    setInviteEmail("");
+    setInviteRole("viewer");
+    setError(null);
+    onClose(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-w-xl rounded-2xl">
         <DialogHeader>
           <DialogTitle>Access management</DialogTitle>
         </DialogHeader>
-
-        <div className="flex items-center gap-2">
+        <div className="flex gap-2">
           <Input
             type="email"
-            placeholder="Enter email address"
+            placeholder="Add people"
             value={inviteEmail}
-            onChange={(e) => setInviteEmail(e.target.value)}
-            className="border bg-white rounded-md px-3 py-2 text-sm w-full"
+            onChange={(e) => {
+              setInviteEmail(e.target.value);
+              setError(null);
+            }}
           />
-
           <Select
             value={inviteRole}
             onValueChange={(v) => setInviteRole(v as Role)}
@@ -66,82 +109,58 @@ export function ModalPublicSet({ open, onClose, defaultRole, onSave }: Props) {
             </SelectContent>
           </Select>
 
-          <Button
-            onClick={() => {
-              console.log("Invite:", inviteEmail, inviteRole);
-              setInviteEmail("");
-            }}
-          >
+          <Button onClick={handleInvite} disabled={loading || !setId}>
             Send
           </Button>
         </div>
-
+        {error && <p className="text-sm text-destructive mt-1">{error}</p>}
         <Separator />
-
         <div className="space-y-3">
           <p className="text-sm font-medium text-muted-foreground">
             People with access
           </p>
-
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Avatar>
-                <AvatarImage src="/avatar.png" />
-                <AvatarFallback>X</AvatarFallback>
-              </Avatar>
-
-              <div className="text-sm">
-                <p className="font-medium">Xa be (Owner)</p>
-                <p className="text-xs text-muted-foreground">
-                  bsa30012@gmail.com
-                </p>
-              </div>
-            </div>
-
+          <div className="flex items-center justify-between py-2">
+            <UserInfo />
             <span className="text-sm text-muted-foreground">Owner</span>
           </div>
-        </div>
-
-        <Separator />
-
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-start gap-3">
-            <Globe className="h-5 w-5 mt-1 text-muted-foreground" />
-            <div className="space-y-1">
-              <p className="font-medium">Anyone with the link</p>
-              <p className="text-sm text-muted-foreground">
-                Anyone on the internet with the link can access this set
-              </p>
+          {accessList.map((item: AccessUser) => (
+            <div key={item.id} className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center text-md">
+                  {item.user?.username?.charAt(0).toUpperCase() ?? "U"}
+                </div>
+                <div>
+                  <p className="text-sm font-medium">
+                    {item.user?.username ?? "Unknown"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {item.user?.email}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  {item.permission === "EDIT" ? "Editor" : "Viewer"}
+                </span>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => remove(item.id)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
-          </div>
-
-          <Select
-            value={publicRole}
-            onValueChange={(v) => setPublicRole(v as Role)}
-          >
-            <SelectTrigger className="w-[120px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="viewer">Viewer</SelectItem>
-              <SelectItem value="editor">Editor</SelectItem>
-            </SelectContent>
-          </Select>
+          ))}
         </div>
-
+        <Separator />
+        <PublicAccessSelect defaultRole={defaultRole} />
         <DialogFooter className="flex justify-between">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigator.clipboard.writeText(window.location.href)}
-            className="rounded-full"
-          >
+          <Button variant="outline" onClick={handleCopyLink}>
+            <Link2 />
             Copy link
           </Button>
-
-          <Button type="button" onClick={handleSave} className="rounded-full">
-            Save
-          </Button>
+          <Button onClick={handleClose}>Done</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/set/PublicAccessSelect.tsx
+++ b/src/components/set/PublicAccessSelect.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { LockKeyhole, Globe } from "lucide-react";
+
+type Role = "viewer" | "editor";
+type PublicAccess = "RESTRICTED" | "ANYONE";
+
+export default function PublicAccessSelect({
+  defaultRole,
+}: {
+  defaultRole: Role;
+}) {
+  const [publicAccess, setPublicAccess] = useState<PublicAccess>("RESTRICTED");
+  const [publicRole, setPublicRole] = useState<Role>(defaultRole);
+
+  return (
+    <div className="flex items-center justify-between">
+      <Select
+        value={publicAccess}
+        onValueChange={(v) => setPublicAccess(v as PublicAccess)}
+      >
+        <SelectTrigger className="w-[400px] border-none shadow-none p-0 h-auto hover:bg-muted/40 rounded-lg text-left">
+          <SelectValue>
+            {publicAccess === "ANYONE" ? (
+              <div className="flex gap-3 p-3">
+                <Globe className="h-5 w-5" />
+                <div>
+                  <p className="text-sm font-medium">Anyone with the link</p>
+                  <p className="text-xs text-muted-foreground">
+                    Anyone on the internet with the link
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex gap-3 p-3">
+                <LockKeyhole className="h-5 w-5" />
+                <div>
+                  <p className="text-sm font-medium">Restricted</p>
+                  <p className="text-xs text-muted-foreground">
+                    Only people with access
+                  </p>
+                </div>
+              </div>
+            )}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="RESTRICTED">Restricted</SelectItem>
+          <SelectItem value="ANYONE">Anyone with the link</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select
+        value={publicRole}
+        onValueChange={(v) => setPublicRole(v as Role)}
+        disabled={publicAccess === "RESTRICTED"}
+      >
+        <SelectTrigger className="w-28">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="viewer">Viewer</SelectItem>
+          <SelectItem value="editor">Editor</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/components/set/SetFormContainer.tsx
+++ b/src/components/set/SetFormContainer.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react-hooks/incompatible-library */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { FormProvider, useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { setSchema, type SetFormValues } from "@/schema/flashCard.schema";
 import { SetForm } from "./SetForm";
 import { SetFormHeader } from "./SetFormHeader";
@@ -38,9 +38,9 @@ export function SetFormContainer({
   draftKey,
 }: Props) {
   const navigate = useNavigate();
+  const { id: setId } = useParams<{ id: string }>();
   const isViewMode = mode === "view";
   const isCreateMode = mode === "create";
-
   const [submitAction, setSubmitAction] = useState<SubmitAction>(
     isCreateMode ? "create" : "update"
   );
@@ -77,7 +77,8 @@ export function SetFormContainer({
           ...value,
           cards: value.cards?.map((card: any) => ({
             ...card,
-            image_url: typeof card?.image_url === "string" ? card.image_url : "",
+            image_url:
+              typeof card?.image_url === "string" ? card.image_url : "",
           })),
         })
       );
@@ -86,9 +87,6 @@ export function SetFormContainer({
     return () => subscription.unsubscribe();
   }, [methods, draftKey]);
 
-  const handleImportCards = (cards: SetFormValues["cards"]) => {
-    replace(cards);
-  };
   const handleFormSubmit = async (data: SetFormValues) => {
     if (isViewMode) return;
     await onSubmit(data, submitAction);
@@ -99,118 +97,100 @@ export function SetFormContainer({
     handleSubmit(handleFormSubmit)();
   };
   const handleCancel = () => {
-    if (draftKey) {
-      localStorage.removeItem(draftKey);
-    }
-
+    if (draftKey) localStorage.removeItem(draftKey);
     navigate("/library");
+  };
+  const handleOpenShareModal = () => {
+    if (!setId) return;
+    setOpenPublicModal(true);
   };
   return (
     <FormProvider {...methods}>
-      <form className="min-h-screen md:px-12 space-y-4 max-w-5xl mx-auto">
-        <SetFormHeader
-          mode={mode}
-          isPublic={isPublic}
-          submitLabel={submitLabel}
-          isSubmitting={isSubmitting}
-          onBack={handleCancel}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onTogglePublic={() => methods.setValue("isPublic", !isPublic)}
-          onOpenPublicModal={() => setOpenPublicModal(true)}
-          onSubmit={() => submitWithAction(isCreateMode ? "create" : "update")}
-        />
-
-        <div className="space-y-4">
-          {isViewMode ? (
-            <div className="space-y-2 border-b pb-4 border-gray-200">
-              <div className="max-w-full overflow-hidden">
-                <h1
-                  className="text-xl font-bold text-gray-900 truncate leading-tight"
-                  title={watch("title")}
-                >
-                  <span>Title:</span> {watch("title") || "Untitled Set"}
-                </h1>
-              </div>
-
-              {watch("description") && (
-                <div className="max-w-full overflow-hidden">
-                  <p
-                    className="text-md text-gray-600 truncate"
-                    title={watch("description")}
-                  >
-                    {watch("description")}
-                  </p>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <InputSet
-                placeholder="Title"
-                className="text-md font-bold border-gray-300 shadow-none focus:ring-0"
-                {...register("title")}
-              />
-              {errors.title && (
-                <p className="text-sm text-red-500 mt-1">
-                  {errors.title.message}
-                </p>
-              )}
-              <Textarea
-                placeholder="Description"
-                className="resize-none border-gray-300 shadow-none focus:ring-0 min-h-[100px]"
-                {...register("description")}
-              />
-              {errors.description && (
-                <p className="text-sm text-red-500">
-                  {errors.description.message}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-        {!isViewMode && (
-          <SetFormControls
-            control={control}
-            onImportCards={handleImportCards}
-            onDeleteAllCards={async () => {
-              for (let i = fields.length - 1; i >= 0; i--) remove(i);
-            }}
-          />
-        )}
-        {fields.map((field, index) => (
-          <SetForm
-            key={field.id}
-            index={index}
-            disabled={isViewMode}
-            onRemove={isViewMode ? undefined : () => remove(index)}
-          />
-        ))}
-        {!isViewMode && (
-          <SetFormFooter
+      <>
+        <form className="min-h-screen md:px-12 space-y-4 max-w-5xl mx-auto">
+          <SetFormHeader
+            mode={mode}
+            isPublic={isPublic}
             submitLabel={submitLabel}
-            showStudyButton={showStudyButton}
             isSubmitting={isSubmitting}
-            onAddCard={() =>
-              append({ term: "", definition: "", example: "", image_url: "" })
-            }
-            onCancel={handleCancel}
+            onBack={handleCancel}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onTogglePublic={() => methods.setValue("isPublic", !isPublic)}
+            onOpenPublicModal={handleOpenShareModal}
             onSubmit={() =>
               submitWithAction(isCreateMode ? "create" : "update")
             }
-            onCreateAndStudy={() => submitWithAction("create_and_study")}
           />
-        )}
+          <div className="space-y-4">
+            {isViewMode ? (
+              <div className="space-y-2 border-b pb-4">
+                <h1 className="text-xl font-bold truncate">
+                  {watch("title") || "Untitled Set"}
+                </h1>
+                {watch("description") && (
+                  <p className="text-gray-600 truncate">
+                    {watch("description")}
+                  </p>
+                )}
+              </div>
+            ) : (
+              <>
+                <InputSet placeholder="Title" {...register("title")} />
+                {errors.title && (
+                  <p className="text-sm text-red-500">{errors.title.message}</p>
+                )}
+                <Textarea
+                  placeholder="Description"
+                  {...register("description")}
+                />
+              </>
+            )}
+          </div>
+          {!isViewMode && (
+            <SetFormControls
+              control={control}
+              onImportCards={replace}
+              onDeleteAllCards={async () => {
+                for (let i = fields.length - 1; i >= 0; i--) remove(i);
+              }}
+            />
+          )}
+          {fields.map((field, index) => (
+            <SetForm
+              key={field.id}
+              index={index}
+              disabled={isViewMode}
+              onRemove={isViewMode ? undefined : () => remove(index)}
+            />
+          ))}
+          {!isViewMode && (
+            <SetFormFooter
+              submitLabel={submitLabel}
+              showStudyButton={showStudyButton}
+              isSubmitting={isSubmitting}
+              onAddCard={() =>
+                append({
+                  term: "",
+                  definition: "",
+                  example: "",
+                  image_url: "",
+                })
+              }
+              onCancel={handleCancel}
+              onSubmit={() =>
+                submitWithAction(isCreateMode ? "create" : "update")
+              }
+              onCreateAndStudy={() => submitWithAction("create_and_study")}
+            />
+          )}
+        </form>
         <ModalPublicSet
           open={openPublicModal}
-          onClose={() => setOpenPublicModal(false)}
-          defaultRole="viewer"
-          onSave={() => {
-            methods.setValue("isPublic", true);
-            setOpenPublicModal(false);
-          }}
+          onClose={setOpenPublicModal}
+          setId={setId}
         />
-      </form>
+      </>
     </FormProvider>
   );
 }

--- a/src/components/set/SetFormHeader.tsx
+++ b/src/components/set/SetFormHeader.tsx
@@ -22,7 +22,6 @@ export function SetFormHeader({
   mode,
   submitLabel,
   onTogglePublic,
-  onOpenPublicModal,
   onBack,
   onEdit,
   onDelete,
@@ -56,7 +55,6 @@ export function SetFormHeader({
               action={onDelete}
               successTitle="Deleted"
               successDescription="Set has been deleted."
-              // onClose={() => {}}
             >
               <Button
                 type="button"
@@ -73,7 +71,6 @@ export function SetFormHeader({
           <div className="flex items-center gap-3">
             <span
               className="px-4 py-1 rounded-full bg-purple-600 text-sm text-white cursor-pointer"
-              onClick={onOpenPublicModal}
             >
               Public
             </span>

--- a/src/hooks/useSetAccess.ts
+++ b/src/hooks/useSetAccess.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { accessService } from "@/services/access.service";
+import type { AccessUser } from "@/services/access.service";
+
+export function useSetAccess(setId?: string) {
+  const [accessList, setAccessList] = useState<AccessUser[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!setId) return;
+
+    let cancelled = false;
+
+    accessService
+      .getSetAccess(setId)
+      .then((res) => {
+        const list = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res?.data?.data)
+          ? res.data.data
+          : Array.isArray(res?.data?.items)
+          ? res.data.items
+          : [];
+
+        if (!cancelled) {
+          setAccessList(list);
+        }
+      })
+      .catch(console.error);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [setId]);
+
+  const invite = async (email: string, permission: "VIEW" | "EDIT") => {
+    if (!setId) throw new Error("Missing setId");
+
+    setLoading(true);
+    try {
+      await accessService.inviteUser({ setId, email, permission });
+
+      const res = await accessService.getSetAccess(setId);
+
+      const list = Array.isArray(res?.data)
+        ? res.data
+        : Array.isArray(res?.data?.data)
+        ? res.data.data
+        : Array.isArray(res?.data?.items)
+        ? res.data.items
+        : [];
+
+      setAccessList(list);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const remove = async (accessId: string) => {
+    setAccessList((prev) => prev.filter((i) => i.id !== accessId));
+    await accessService.removeAccess(accessId);
+  };
+
+  return {
+    accessList,
+    loading,
+    invite,
+    remove,
+  };
+}

--- a/src/pages/SetStudyPage.tsx
+++ b/src/pages/SetStudyPage.tsx
@@ -165,7 +165,7 @@ export default function SetStudyPage() {
       <div className="max-w-3xl mx-auto px-4 py-6">
         <div className="flex justify-between items-center mb-6">
           <h3 className="text-2xl font-semibold">{setTitle}</h3>
-          <ToggleGroupSpacing />
+          <ToggleGroupSpacing setId={id ? id : ""} />
         </div>
 
         <div className="grid grid-cols-2 gap-4 mb-6 mx-24">
@@ -244,8 +244,6 @@ export default function SetStudyPage() {
       <div className="max-w-6xl mx-auto px-4 pb-10">
         <UserInfo />
         <p className="font-semibold">{setTitle}</p>
-        {/* <h2 className="font-semibold mt-4">You have also learned</h2>
-        <LearnedList /> */}
         <h2 className="mt-4">Terminology in this module ({cards.length})</h2>
         <CardList cards={cards} />
       </div>

--- a/src/services/access.service.ts
+++ b/src/services/access.service.ts
@@ -1,0 +1,37 @@
+import apiClient from "./apiClient";
+
+export type Permission = "EDIT" | "VIEW";
+
+export type AccessUser = {
+  id: string;
+  permission: Permission;
+  user: {
+    id: string;
+    username: string;
+    email: string;
+    avatar?: string;
+  };
+};
+
+export type InviteAccessPayload = {
+  setId: string;
+  email: string;
+  permission: Permission;
+};
+
+export const accessService = {
+  getSetAccess(setId: string) {
+    if (!setId) {
+      return Promise.resolve({ data: [] });
+    }
+    return apiClient.get(`/api/v1/access/set/${setId}`);
+  },
+
+  inviteUser(payload: InviteAccessPayload) {
+    return apiClient.post("/api/v1/access", payload);
+  },
+
+  removeAccess(accessId: string) {
+    return apiClient.delete(`/api/v1/access/${accessId}`);
+  },
+};


### PR DESCRIPTION
Tính năng cho phép chủ sở hữu Set chia sẻ quyền truy cập cho người dùng khác thông qua email, với 2 mức quyền: Viewer và Editor. Toàn bộ luồng được xử lý phía Frontend, kết hợp validate dữ liệu và xử lý phản hồi từ Backend.

1. Mở modal Share
Khi người dùng nhấn Share, modal ModalPublicSet được mở
<img width="1783" height="879" alt="image" src="https://github.com/user-attachments/assets/0fc1bdad-4a0a-4e56-b807-dbdf50831a3a" />
2. Nhập và gửi lời mời (Invite)
Người dùng nhập: Email, Quyền truy cập
Validate phía Frontend:
Email rỗng → hiển thị lỗi
<img width="1745" height="861" alt="image" src="https://github.com/user-attachments/assets/97d2312c-5e1f-40fc-92b4-37532dacee7e" />
Email sai định dạng → hiển thị lỗi
<img width="1787" height="837" alt="image" src="https://github.com/user-attachments/assets/a9e49ff8-b3c4-46d3-a4fa-9838850d578e" />
3. Gửi lời mời
Khi dữ liệu hợp lệ:
Disable nút Send trong lúc loading
Thành công:
Reset input (email, role)
UI tự động cập nhật
<img width="1735" height="840" alt="image" src="https://github.com/user-attachments/assets/f993fa06-c235-4cd6-a2ad-452c6e3825a3" />
Thất bại:
Hiển thị thông báo lỗi từ Backend (email không tồn tại, đã có quyền, …)
Không reset dữ liệu người dùng đã nhập
<img width="1819" height="891" alt="image" src="https://github.com/user-attachments/assets/50e67227-eefd-49cd-aae5-20264a530048" />
4. Xóa quyền truy cập
Người dùng nhấn nút Remove
Frontend gọi API xóa quyền
Sau khi thành công:
Cập nhật lại accessList
UI re-render theo dữ liệu mới
<img width="1791" height="839" alt="image" src="https://github.com/user-attachments/assets/7a4b3c43-1062-4098-b373-6731a43dbe64" />