### PR TITLE
fix(ui): center initial website loading state and add spinner

### DIFF
--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Loader2 } from "lucide-react";
+
+interface LoadingSpinnerProps {
+  text?: string;
+  className?: string;
+}
+
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+  text = "Loading...",
+  className = "min-h-screen",
+}) => {
+  return (
+    <div className={`flex flex-col items-center justify-center w-full gap-3 ${className}`}>
+      <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      {text && <span className="text-sm font-medium text-slate-600">{text}</span>}
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import ProtectedRoute from "../routes/ProtectedRoute";
 import MainLayout from "../layouts/MainLayout";
 import { LoginPage, LibraryPage } from "./lazyPages";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 import SignupPage from "@/pages/SignupPage";
 import VerifyEmailNoticePage from "@/pages/VerifyEmailNoticePage";
 import VerifyEmailFailPage from "@/pages/VerifyEmailFailPage";
@@ -24,7 +25,7 @@ import NotificationPage from "@/pages/NotificationPage";
 
 function App() {
   return (
-    <Suspense fallback={<div>Loading page...</div>}>
+    <Suspense fallback={<LoadingSpinner text="Loading page..." />}>
       <Routes>
         <Route path="/signup" element={<SignupPage />} />
         <Route path="/login" element={<LoginPage />} />

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,11 +1,12 @@
 import { Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
+import LoadingSpinner from "@/components/common/LoadingSpinner";
 
 const ProtectedRoute = () => {
   const { isAuthenticated, loading } = useAuth();
 
   if (loading) {
-    return <div>Loading...</div>;
+    return <LoadingSpinner text="Loading..." />;
   }
 
   if (!isAuthenticated) {


### PR DESCRIPTION
## Description
- Updated the initial website loading state (auth initialization & route suspense) to be centered vertically and horizontally on the page.
- Added a loading spinner icon (Loader2 with nimate-spin).